### PR TITLE
feat: add expanded querystring feature

### DIFF
--- a/server/routes/peopleRoutes.js
+++ b/server/routes/peopleRoutes.js
@@ -9,97 +9,100 @@ const People = require("../models/peopleModel");
 
 // Search
 const searchQuery = (req, res, next) => {
-	if (!req.query.name) {
-		next();
-	} else {
-		People.find(
-			{
-				"properties.name": { $regex: `${req.query.name}`, $options: "i" },
-			},
-			(err, results) => {
-				if (err) {
-					res
-						.status(400)
-						.json({ errors: `${err}`, message: "Could not find film" });
-				} else if (results) {
-					withWookie(req, res, results);
-				} else {
-					res.status(404).json({ message: "No results, refine your query" });
-				}
-			}
-		);
-	}
+  if (!req.query.name) {
+    next();
+  } else {
+    People.find(
+      {
+        "properties.name": { $regex: `${req.query.name}`, $options: "i" },
+      },
+      (err, results) => {
+        if (err) {
+          res
+            .status(400)
+            .json({ errors: `${err}`, message: "Could not find film" });
+        } else if (results) {
+          withWookie(req, res, results);
+        } else {
+          res.status(404).json({ message: "No results, refine your query" });
+        }
+      }
+    );
+  }
 };
 
 // GET all
 peopleRouter.get("/people", searchQuery, async (req, res) => {
-	const { page, limit } = req.query;
+  const { page, limit, expanded } = req.query;
 
-	People.countDocuments((err, total) => {
-		if (err) {
-			return res.status(400).json({ error: true, message: "Could not Count" });
-		}
-		const pageNumber =
-			page && limit
-				? parseInt(page) < 1
-					? 1
-					: parseInt(page) > Math.ceil(total / limit)
-					? Math.ceil(total / limit)
-					: parseInt(page)
-				: 1;
-		const resultLimit =
-			page && limit ? (parseInt(limit) > total ? total : parseInt(limit)) : 10;
+  People.countDocuments((err, total) => {
+    if (err) {
+      return res.status(400).json({ error: true, message: "Could not Count" });
+    }
+    const pageNumber =
+      page && limit
+        ? parseInt(page) < 1
+          ? 1
+          : parseInt(page) > Math.ceil(total / limit)
+          ? Math.ceil(total / limit)
+          : parseInt(page)
+        : 1;
+    const resultLimit =
+      page && limit ? (parseInt(limit) > total ? total : parseInt(limit)) : 10;
 
-		const peoplePagination = new Paginate(req, pageNumber, resultLimit, total);
-		const pager = peoplePagination.paginate();
+    const peoplePagination = new Paginate(req, pageNumber, resultLimit, total);
+    const pager = peoplePagination.paginate();
 
-		People.find(
-			{},
-			{},
-			{ ...peoplePagination.query, sort: { _id: 1 } },
-			(err, results) => {
-				if (err) {
-					res
-						.status(400)
-						.json({ message: "Could not GET people", errors: `${err}` });
-				} else if (results) {
-					withWookie(req, res, {
-						...pager,
-						results: [
-							...results.map((person) => {
-								return {
-									uid: person.uid,
-									name: person.properties.name,
-									url: person.properties.url,
-								};
-							}),
-						],
-					});
-				} else {
-					res.status(404).json({ message: "Not Found" });
-				}
-			}
-		);
-	});
+    People.find(
+      {},
+      {},
+      { ...peoplePagination.query, sort: { _id: 1 } },
+      (err, results) => {
+        if (err) {
+          res
+            .status(400)
+            .json({ message: "Could not GET people", errors: `${err}` });
+        } else if (results) {
+          withWookie(req, res, {
+            ...pager,
+            results: [
+              ...results.map((person) => {
+                if (expanded) {
+                  return person;
+                }
+                return {
+                  uid: person.uid,
+                  name: person.properties.name,
+                  url: person.properties.url,
+                };
+              }),
+            ],
+          });
+        } else {
+          res.status(404).json({ message: "Not Found" });
+        }
+      }
+    );
+  });
 });
 
 // GET one
 peopleRouter.get("/people/:id", checkCache, (req, res) => {
-	People.findOne({ uid: req.params.id }, (err, person) => {
-		if (err) {
-			res
-				.status(400)
-				.json({ message: "Could not GET person", errors: `${err}` });
-		} else if (person) {
-			if (!isWookiee(req)) {
-				setCache(req, person.toObject());
-			}
+  People.findOne({ uid: req.params.id }, (err, person) => {
+    if (err) {
+      res
+        .status(400)
+        .json({ message: "Could not GET person", errors: `${err}` });
+    } else if (person) {
+      if (!isWookiee(req)) {
+        setCache(req, person.toObject());
+      }
 
-			withWookie(req, res, person, false);
-		} else {
-			res.status(404).json({ message: "not found" });
-		}
-	});
+      withWookie(req, res, person, false);
+    } else {
+      res.status(404).json({ message: "not found" });
+    }
+  });
 });
 
 module.exports = peopleRouter;

--- a/server/routes/planetRoutes.js
+++ b/server/routes/planetRoutes.js
@@ -8,97 +8,100 @@ const Paginate = require("../helpers/pagination");
 const Planets = require("../models/planetModel");
 
 const searchQuery = (req, res, next) => {
-	if (!req.query.name) {
-		next();
-	} else {
-		Planets.find(
-			{
-				"properties.name": { $regex: `${req.query.name}`, $options: "i" },
-			},
-			(err, results) => {
-				if (err) {
-					res
-						.status(400)
-						.json({ errors: `${err}`, message: "Could not find planet" });
-				} else if (results) {
-					withWookie(req, res, results);
-				} else {
-					res.status(404).json({ message: "No results, refine your query" });
-				}
-			}
-		);
-	}
+  if (!req.query.name) {
+    next();
+  } else {
+    Planets.find(
+      {
+        "properties.name": { $regex: `${req.query.name}`, $options: "i" },
+      },
+      (err, results) => {
+        if (err) {
+          res
+            .status(400)
+            .json({ errors: `${err}`, message: "Could not find planet" });
+        } else if (results) {
+          withWookie(req, res, results);
+        } else {
+          res.status(404).json({ message: "No results, refine your query" });
+        }
+      }
+    );
+  }
 };
 
 // GET all
 planetRouter.get("/planets", searchQuery, (req, res) => {
-	const { page, limit } = req.query;
+  const { page, limit, expanded } = req.query;
 
-	Planets.countDocuments((err, total) => {
-		if (err) {
-			return res.status(400).json({ error: true, message: "Could not Count" });
-		}
-		const pageNumber =
-			page && limit
-				? parseInt(page) < 1
-					? 1
-					: parseInt(page) > Math.ceil(total / limit)
-					? Math.ceil(total / limit)
-					: parseInt(page)
-				: 1;
-		const resultLimit =
-			page && limit ? (parseInt(limit) > total ? total : parseInt(limit)) : 10;
+  Planets.countDocuments((err, total) => {
+    if (err) {
+      return res.status(400).json({ error: true, message: "Could not Count" });
+    }
+    const pageNumber =
+      page && limit
+        ? parseInt(page) < 1
+          ? 1
+          : parseInt(page) > Math.ceil(total / limit)
+          ? Math.ceil(total / limit)
+          : parseInt(page)
+        : 1;
+    const resultLimit =
+      page && limit ? (parseInt(limit) > total ? total : parseInt(limit)) : 10;
 
-		const planetPagination = new Paginate(req, pageNumber, resultLimit, total);
-		const pager = planetPagination.paginate();
+    const planetPagination = new Paginate(req, pageNumber, resultLimit, total);
+    const pager = planetPagination.paginate();
 
-		Planets.find(
-			{},
-			{},
-			{ ...planetPagination.query, sort: { _id: 1 } },
-			(err, results) => {
-				if (err) {
-					res
-						.status(400)
-						.json({ message: "Could not GET planets", errors: `${err}` });
-				} else if (results) {
-					withWookie(req, res, {
-						...pager,
-						results: [
-							...results.map((planet) => {
-								return {
-									uid: planet.uid,
-									name: planet.properties.name,
-									url: planet.properties.url,
-								};
-							}),
-						],
-					});
-				} else {
-					res.status(404).end();
-				}
-			}
-		);
-	});
+    Planets.find(
+      {},
+      {},
+      { ...planetPagination.query, sort: { _id: 1 } },
+      (err, results) => {
+        if (err) {
+          res
+            .status(400)
+            .json({ message: "Could not GET planets", errors: `${err}` });
+        } else if (results) {
+          withWookie(req, res, {
+            ...pager,
+            results: [
+              ...results.map((planet) => {
+                if (expanded) {
+                  return planet;
+                }
+                return {
+                  uid: planet.uid,
+                  name: planet.properties.name,
+                  url: planet.properties.url,
+                };
+              }),
+            ],
+          });
+        } else {
+          res.status(404).end();
+        }
+      }
+    );
+  });
 });
 
 // GET one
 planetRouter.get("/planets/:id", checkCache, (req, res) => {
-	Planets.findOne({ uid: req.params.id }, (err, planet) => {
-		if (err) {
-			res
-				.status(400)
-				.json({ message: "Could not GET planet", errors: `${err}` });
-		} else if (planet) {
-			if (!isWookiee(req)) {
-				setCache(req, planet.toObject());
-			}
+  Planets.findOne({ uid: req.params.id }, (err, planet) => {
+    if (err) {
+      res
+        .status(400)
+        .json({ message: "Could not GET planet", errors: `${err}` });
+    } else if (planet) {
+      if (!isWookiee(req)) {
+        setCache(req, planet.toObject());
+      }
 
-			withWookie(req, res, planet, false);
-		} else {
-			res.status(404).json({ message: "not found" });
-		}
-	});
+      withWookie(req, res, planet, false);
+    } else {
+      res.status(404).json({ message: "not found" });
+    }
+  });
 });
 
 module.exports = planetRouter;

--- a/server/routes/speciesRoutes.js
+++ b/server/routes/speciesRoutes.js
@@ -9,97 +9,100 @@ const SpeciesModel = require("../models/speciesModel");
 
 // Search
 const searchQuery = (req, res, next) => {
-	if (!req.query.name) {
-		next();
-	} else {
-		SpeciesModel.find(
-			{
-				"properties.name": { $regex: `${req.query.name}`, $options: "i" },
-			},
-			(err, results) => {
-				if (err) {
-					res
-						.status(400)
-						.json({ errors: `${err}`, message: "Could not find specie" });
-				} else if (results) {
-					withWookie(req, res, results);
-				} else {
-					res.status(404).json({ message: "No results, refine your query" });
-				}
-			}
-		);
-	}
+  if (!req.query.name) {
+    next();
+  } else {
+    SpeciesModel.find(
+      {
+        "properties.name": { $regex: `${req.query.name}`, $options: "i" },
+      },
+      (err, results) => {
+        if (err) {
+          res
+            .status(400)
+            .json({ errors: `${err}`, message: "Could not find specie" });
+        } else if (results) {
+          withWookie(req, res, results);
+        } else {
+          res.status(404).json({ message: "No results, refine your query" });
+        }
+      }
+    );
+  }
 };
 
 // GET all
 speciesRouter.get("/species", searchQuery, (req, res) => {
-	const { page, limit } = req.query;
+  const { page, limit, expanded } = req.query;
 
-	SpeciesModel.countDocuments((err, total) => {
-		if (err) {
-			return res.status(400).json({ error: true, message: "Could not Count" });
-		}
-		const pageNumber =
-			page && limit
-				? parseInt(page) < 1
-					? 1
-					: parseInt(page) > Math.ceil(total / limit)
-					? Math.ceil(total / limit)
-					: parseInt(page)
-				: 1;
-		const resultLimit =
-			page && limit ? (parseInt(limit) > total ? total : parseInt(limit)) : 10;
+  SpeciesModel.countDocuments((err, total) => {
+    if (err) {
+      return res.status(400).json({ error: true, message: "Could not Count" });
+    }
+    const pageNumber =
+      page && limit
+        ? parseInt(page) < 1
+          ? 1
+          : parseInt(page) > Math.ceil(total / limit)
+          ? Math.ceil(total / limit)
+          : parseInt(page)
+        : 1;
+    const resultLimit =
+      page && limit ? (parseInt(limit) > total ? total : parseInt(limit)) : 10;
 
-		const speciesPagination = new Paginate(req, pageNumber, resultLimit, total);
-		const pager = speciesPagination.paginate();
+    const speciesPagination = new Paginate(req, pageNumber, resultLimit, total);
+    const pager = speciesPagination.paginate();
 
-		SpeciesModel.find(
-			{},
-			{},
-			{ ...speciesPagination.query, sort: { _id: 1 } },
-			(err, results) => {
-				if (err) {
-					res
-						.status(400)
-						.json({ message: "Could not GET species", errors: `${err}` });
-				} else if (results) {
-					withWookie(req, res, {
-						...pager,
-						results: [
-							...results.map((specimen) => {
-								return {
-									uid: specimen.uid,
-									name: specimen.properties.name,
-									url: specimen.properties.url,
-								};
-							}),
-						],
-					});
-				} else {
-					res.status(404).end();
-				}
-			}
-		);
-	});
+    SpeciesModel.find(
+      {},
+      {},
+      { ...speciesPagination.query, sort: { _id: 1 } },
+      (err, results) => {
+        if (err) {
+          res
+            .status(400)
+            .json({ message: "Could not GET species", errors: `${err}` });
+        } else if (results) {
+          withWookie(req, res, {
+            ...pager,
+            results: [
+              ...results.map((specimen) => {
+                if (expanded) {
+                  return specimen;
+                }
+                return {
+                  uid: specimen.uid,
+                  name: specimen.properties.name,
+                  url: specimen.properties.url,
+                };
+              }),
+            ],
+          });
+        } else {
+          res.status(404).end();
+        }
+      }
+    );
+  });
 });
 
 // GET one
 speciesRouter.get("/species/:id", checkCache, (req, res) => {
-	SpeciesModel.findOne({ uid: req.params.id }, (err, species) => {
-		if (err) {
-			res
-				.status(400)
-				.json({ message: "Could not GET species", errors: `${err}` });
-		} else if (species) {
-			if (!isWookiee(req)) {
-				setCache(req, species.toObject());
-			}
+  SpeciesModel.findOne({ uid: req.params.id }, (err, species) => {
+    if (err) {
+      res
+        .status(400)
+        .json({ message: "Could not GET species", errors: `${err}` });
+    } else if (species) {
+      if (!isWookiee(req)) {
+        setCache(req, species.toObject());
+      }
 
-			withWookie(req, res, species);
-		} else {
-			res.status(404).json({ message: "not found" });
-		}
-	});
+      withWookie(req, res, species);
+    } else {
+      res.status(404).json({ message: "not found" });
+    }
+  });
 });
 
 module.exports = speciesRouter;

--- a/server/routes/starshipRoutes.js
+++ b/server/routes/starshipRoutes.js
@@ -9,114 +9,117 @@ const StarshipModel = require("../models/starshipModel");
 
 // Search
 const searchQuery = (req, res, next) => {
-	const { name, model } = req.query;
+  const { name, model } = req.query;
 
-	if (!name && !model) {
-		next();
-	} else {
-		StarshipModel.find(
-			{
-				$or: [
-					{
-						"properties.name": { $regex: `${name}`, $options: "i" },
-					},
-					{
-						"properties.model": {
-							$regex: `${model}`,
-							$options: "i",
-						},
-					},
-				],
-			},
-			(err, results) => {
-				if (err) {
-					res
-						.status(400)
-						.json({ errors: `${err}`, message: "Could not find starship" });
-				} else if (results) {
-					withWookie(req, res, results);
-				} else {
-					res.status(404).json({ message: "No results, refine your query" });
-				}
-			}
-		);
-	}
+  if (!name && !model) {
+    next();
+  } else {
+    StarshipModel.find(
+      {
+        $or: [
+          {
+            "properties.name": { $regex: `${name}`, $options: "i" },
+          },
+          {
+            "properties.model": {
+              $regex: `${model}`,
+              $options: "i",
+            },
+          },
+        ],
+      },
+      (err, results) => {
+        if (err) {
+          res
+            .status(400)
+            .json({ errors: `${err}`, message: "Could not find starship" });
+        } else if (results) {
+          withWookie(req, res, results);
+        } else {
+          res.status(404).json({ message: "No results, refine your query" });
+        }
+      }
+    );
+  }
 };
 
 // GET all
 starshipRouter.get("/starships", searchQuery, (req, res) => {
-	const { page, limit } = req.query;
+  const { page, limit, expanded } = req.query;
 
-	StarshipModel.countDocuments((err, total) => {
-		if (err) {
-			return res.status(400).json({ error: true, message: "Could not Count" });
-		}
-		const pageNumber =
-			page && limit
-				? parseInt(page) < 1
-					? 1
-					: parseInt(page) > Math.ceil(total / limit)
-					? Math.ceil(total / limit)
-					: parseInt(page)
-				: 1;
-		const resultLimit =
-			page && limit ? (parseInt(limit) > total ? total : parseInt(limit)) : 10;
+  StarshipModel.countDocuments((err, total) => {
+    if (err) {
+      return res.status(400).json({ error: true, message: "Could not Count" });
+    }
+    const pageNumber =
+      page && limit
+        ? parseInt(page) < 1
+          ? 1
+          : parseInt(page) > Math.ceil(total / limit)
+          ? Math.ceil(total / limit)
+          : parseInt(page)
+        : 1;
+    const resultLimit =
+      page && limit ? (parseInt(limit) > total ? total : parseInt(limit)) : 10;
 
-		const starshipPagination = new Paginate(
-			req,
-			pageNumber,
-			resultLimit,
-			total
-		);
-		const pager = starshipPagination.paginate();
+    const starshipPagination = new Paginate(
+      req,
+      pageNumber,
+      resultLimit,
+      total
+    );
+    const pager = starshipPagination.paginate();
 
-		StarshipModel.find(
-			{},
-			{},
-			{ ...starshipPagination.query, sort: { _id: 1 } },
-			(err, results) => {
-				if (err) {
-					res
-						.status(400)
-						.json({ message: "Could not GET starhsips", errors: `${err}` });
-				} else if (results) {
-					withWookie(req, res, {
-						...pager,
-						results: [
-							...results.map((starship) => {
-								return {
-									uid: starship.uid,
-									name: starship.properties.name,
-									url: starship.properties.url,
-								};
-							}),
-						],
-					});
-				} else {
-					res.status(404).end();
-				}
-			}
-		);
-	});
+    StarshipModel.find(
+      {},
+      {},
+      { ...starshipPagination.query, sort: { _id: 1 } },
+      (err, results) => {
+        if (err) {
+          res
+            .status(400)
+            .json({ message: "Could not GET starhsips", errors: `${err}` });
+        } else if (results) {
+          withWookie(req, res, {
+            ...pager,
+            results: [
+              ...results.map((starship) => {
+                if (expanded) {
+                  return starship;
+                }
+                return {
+                  uid: starship.uid,
+                  name: starship.properties.name,
+                  url: starship.properties.url,
+                };
+              }),
+            ],
+          });
+        } else {
+          res.status(404).end();
+        }
+      }
+    );
+  });
 });
 
 // GET one
 starshipRouter.get("/starships/:id", checkCache, (req, res) => {
-	StarshipModel.findOne({ uid: `${req.params.id}` }, (err, starhsips) => {
-		if (err) {
-			res
-				.status(400)
-				.json({ message: "Could not GET starhsips", errors: `${err}` });
-		} else if (starhsips) {
-			if (!isWookiee(req)) {
-				setCache(req, starhsips.toObject());
-			}
+  StarshipModel.findOne({ uid: `${req.params.id}` }, (err, starhsips) => {
+    if (err) {
+      res
+        .status(400)
+        .json({ message: "Could not GET starhsips", errors: `${err}` });
+    } else if (starhsips) {
+      if (!isWookiee(req)) {
+        setCache(req, starhsips.toObject());
+      }
 
-			withWookie(req, res, starhsips);
-		} else {
-			res.status(404).json({ message: "not found" });
-		}
-	});
+      withWookie(req, res, starhsips);
+    } else {
+      res.status(404).json({ message: "not found" });
+    }
+  });
 });
 
 module.exports = starshipRouter;

--- a/server/routes/vehicleRoutes.js
+++ b/server/routes/vehicleRoutes.js
@@ -9,114 +9,117 @@ const VehicleModel = require("../models/vehicleModel");
 
 // Search
 const searchQuery = (req, res, next) => {
-	const { name, model } = req.query;
+  const { name, model } = req.query;
 
-	if (!name && !model) {
-		next();
-	} else {
-		VehicleModel.find(
-			{
-				$or: [
-					{
-						"properties.name": { $regex: `${name}`, $options: "i" },
-					},
-					{
-						"properties.model": {
-							$regex: `${model}`,
-							$options: "i",
-						},
-					},
-				],
-			},
-			(err, results) => {
-				if (err) {
-					res
-						.status(400)
-						.json({ errors: `${err}`, message: "Could not find vehicle" });
-				} else if (results) {
-					withWookie(req, res, results);
-				} else {
-					res.status(404).json({ message: "No results, refine your query" });
-				}
-			}
-		);
-	}
+  if (!name && !model) {
+    next();
+  } else {
+    VehicleModel.find(
+      {
+        $or: [
+          {
+            "properties.name": { $regex: `${name}`, $options: "i" },
+          },
+          {
+            "properties.model": {
+              $regex: `${model}`,
+              $options: "i",
+            },
+          },
+        ],
+      },
+      (err, results) => {
+        if (err) {
+          res
+            .status(400)
+            .json({ errors: `${err}`, message: "Could not find vehicle" });
+        } else if (results) {
+          withWookie(req, res, results);
+        } else {
+          res.status(404).json({ message: "No results, refine your query" });
+        }
+      }
+    );
+  }
 };
 
 // GET all
 vehicleRouter.get("/vehicles", searchQuery, (req, res) => {
-	const { page, limit } = req.query;
+  const { page, limit, expanded } = req.query;
 
-	VehicleModel.countDocuments((err, total) => {
-		if (err) {
-			return res.status(400).json({ error: true, message: "Could not Count" });
-		}
-		const pageNumber =
-			page && limit
-				? parseInt(page) < 1
-					? 1
-					: parseInt(page) > Math.ceil(total / limit)
-					? Math.ceil(total / limit)
-					: parseInt(page)
-				: 1;
-		const resultLimit =
-			page && limit ? (parseInt(limit) > total ? total : parseInt(limit)) : 10;
+  VehicleModel.countDocuments((err, total) => {
+    if (err) {
+      return res.status(400).json({ error: true, message: "Could not Count" });
+    }
+    const pageNumber =
+      page && limit
+        ? parseInt(page) < 1
+          ? 1
+          : parseInt(page) > Math.ceil(total / limit)
+          ? Math.ceil(total / limit)
+          : parseInt(page)
+        : 1;
+    const resultLimit =
+      page && limit ? (parseInt(limit) > total ? total : parseInt(limit)) : 10;
 
-		const starshipPagination = new Paginate(
-			req,
-			pageNumber,
-			resultLimit,
-			total
-		);
-		const pager = starshipPagination.paginate();
+    const starshipPagination = new Paginate(
+      req,
+      pageNumber,
+      resultLimit,
+      total
+    );
+    const pager = starshipPagination.paginate();
 
-		VehicleModel.find(
-			{},
-			{},
-			{ ...starshipPagination.query, sort: { _id: 1 } },
-			(err, results) => {
-				if (err) {
-					res
-						.status(400)
-						.json({ message: "Could not GET vehicles", errors: `${err}` });
-				} else if (results) {
-					withWookie(req, res, {
-						...pager,
-						results: [
-							...results.map((vehicle) => {
-								return {
-									uid: vehicle.uid,
-									name: vehicle.properties.name,
-									url: vehicle.properties.url,
-								};
-							}),
-						],
-					});
-				} else {
-					res.status(404).end();
-				}
-			}
-		);
-	});
+    VehicleModel.find(
+      {},
+      {},
+      { ...starshipPagination.query, sort: { _id: 1 } },
+      (err, results) => {
+        if (err) {
+          res
+            .status(400)
+            .json({ message: "Could not GET vehicles", errors: `${err}` });
+        } else if (results) {
+          withWookie(req, res, {
+            ...pager,
+            results: [
+              ...results.map((vehicle) => {
+                if (expanded) {
+                  return vehicle;
+                }
+                return {
+                  uid: vehicle.uid,
+                  name: vehicle.properties.name,
+                  url: vehicle.properties.url,
+                };
+              }),
+            ],
+          });
+        } else {
+          res.status(404).end();
+        }
+      }
+    );
+  });
 });
 
 // GET one
 vehicleRouter.get("/vehicles/:id", checkCache, (req, res) => {
-	VehicleModel.findOne({ uid: req.params.id }, (err, vehicles) => {
-		if (err) {
-			res
-				.status(400)
-				.json({ message: "Could not GET vehicles", errors: `${err}` });
-		} else if (vehicles) {
-			if (!isWookiee(req)) {
-				setCache(req, vehicles.toObject());
-			}
+  VehicleModel.findOne({ uid: req.params.id }, (err, vehicles) => {
+    if (err) {
+      res
+        .status(400)
+        .json({ message: "Could not GET vehicles", errors: `${err}` });
+    } else if (vehicles) {
+      if (!isWookiee(req)) {
+        setCache(req, vehicles.toObject());
+      }
 
-			withWookie(req, res, vehicles);
-		} else {
-			res.status(404).json({ message: "not found" });
-		}
-	});
+      withWookie(req, res, vehicles);
+    } else {
+      res.status(404).json({ message: "not found" });
+    }
+  });
 });
 
 module.exports = vehicleRouter;


### PR DESCRIPTION
Add support for the `expanded` querystring option.
This will return the full record of the requested resource instead of a abbreviated version of the record.
For example `/api/people/?page=1&limit=2&expanded=true` would return
```
{
  "message": "ok",
  "total_records": 82,
  "total_pages": 41,
  "previous": null,
  "next": "https://swapi.tech/api/people?page=2&limit=2",
  "results": [
    {
      "uid": "1",
      "height": "172",
      "mass": "77",
      "hair_color": "blond",
      "skin_color": "fair",
      "eye_color": "blue",
      "birth_year": "19BBY",
      "gender": "male",
      "created": "2025-02-07T16:44:15.803Z",
      "edited": "2025-02-07T16:44:15.803Z",
      "name": "Luke Skywalker",
      "homeworld": "https://www.swapi.tech/api/planets/1",
      "url": "https://www.swapi.tech/api/people/1"
    },
    {
      "uid": "2",
      "height": "167",
      "mass": "75",
      "hair_color": "n/a",
      "skin_color": "gold",
      "eye_color": "yellow",
      "birth_year": "112BBY",
      "gender": "n/a",
      "created": "2025-02-07T16:44:15.803Z",
      "edited": "2025-02-07T16:44:15.803Z",
      "name": "C-3PO",
      "homeworld": "https://www.swapi.tech/api/planets/1",
      "url": "https://www.swapi.tech/api/people/2"
    }
  ]
}
```
closes #26 